### PR TITLE
:truck: rename get methods to begin with `read`

### DIFF
--- a/expense-tracker/app/main.py
+++ b/expense-tracker/app/main.py
@@ -21,12 +21,12 @@ def get_db():
 
 
 @app.get("/expenses/", response_model=List[schemas.Expense])
-def get_expenses(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+def read_expenses(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
     return crud.get_expenses(db, skip=skip, limit=limit)
 
 
 @app.get("/expenses/{expense_id}", response_model=schemas.Expense)
-def get_expense(expense_id: int, db: Session = Depends(get_db)):
+def read_expense(expense_id: int, db: Session = Depends(get_db)):
     return crud.get_exepense_by_id(db, expense_id)
 
 


### PR DESCRIPTION
Updating GET route method names to begin with `read` to make CRUD operations more readable and easy to follow.