### PR TITLE
:pencil2: fix typo in function name

### DIFF
--- a/expense-tracker/app/crud.py
+++ b/expense-tracker/app/crud.py
@@ -16,7 +16,7 @@ def get_expenses(db: Session, skip: int = 0, limit: int = 10):
     )
 
 
-def get_exepense_by_id(db: Session, expense_id: int):
+def get_expense_by_id(db: Session, expense_id: int):
     return (
         db.query(models.Expense).filter(models.Expense.expense_id == expense_id).first()
     )

--- a/expense-tracker/app/main.py
+++ b/expense-tracker/app/main.py
@@ -27,7 +27,7 @@ def read_expenses(skip: int = 0, limit: int = 10, db: Session = Depends(get_db))
 
 @app.get("/expenses/{expense_id}", response_model=schemas.Expense)
 def read_expense(expense_id: int, db: Session = Depends(get_db)):
-    return crud.get_exepense_by_id(db, expense_id)
+    return crud.get_expense_by_id(db, expense_id)
 
 
 @app.post("/expenses/", response_model=schemas.Expense)


### PR DESCRIPTION
Updating typo in `get_expense_by_id` function name.