### PR TITLE
:bug: move Connector init out of getconn

### DIFF
--- a/expense-tracker/app/database.py
+++ b/expense-tracker/app/database.py
@@ -18,7 +18,8 @@ def init_connection_engine(connector: Connector) -> Engine:
         (os.getenv("DB_IAM_USER"), True)
         if os.getenv("DB_IAM_USER")
         else (os.getenv("DB_USER"), False)
-    ) 
+    )
+
     # Cloud SQL Python Connector creator function
     def getconn():
         conn = connector.connect(
@@ -31,11 +32,12 @@ def init_connection_engine(connector: Connector) -> Engine:
             enable_iam_auth=enable_iam_auth,
         )
         return conn
-    
+
     SQLALCHEMY_DATABASE_URL = "postgresql+pg8000://"
 
     engine = create_engine(SQLALCHEMY_DATABASE_URL, creator=getconn)
     return engine
+
 
 # initialize Python Connector and connection pool engine
 connector = Connector()

--- a/expense-tracker/app/database.py
+++ b/expense-tracker/app/database.py
@@ -1,6 +1,7 @@
 import os
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from google.cloud.sql.connector import Connector, IPTypes
@@ -9,8 +10,7 @@ from google.cloud.sql.connector import Connector, IPTypes
 load_dotenv()
 
 
-# Cloud SQL Python Connector creator function
-def getconn():
+def init_connection_engine(connector: Connector) -> Engine:
     # if env var PRIVATE_IP is set to True, use private IP Cloud SQL connections
     ip_type = IPTypes.PRIVATE if os.getenv("PRIVATE_IP") is True else IPTypes.PUBLIC
     # if env var DB_IAM_USER is set, use IAM database authentication
@@ -18,22 +18,29 @@ def getconn():
         (os.getenv("DB_IAM_USER"), True)
         if os.getenv("DB_IAM_USER")
         else (os.getenv("DB_USER"), False)
-    )
-    # initialize Cloud SQL Python connector object
-    with Connector(ip_type=ip_type, enable_iam_auth=enable_iam_auth) as connector:
+    ) 
+    # Cloud SQL Python Connector creator function
+    def getconn():
         conn = connector.connect(
             os.getenv("INSTANCE_CONNECTION_NAME"),
             "pg8000",
             user=user,
             password=os.getenv("DB_PASS", ""),
             db=os.getenv("DB_NAME"),
+            ip_type=ip_type,
+            enable_iam_auth=enable_iam_auth,
         )
         return conn
+    
+    SQLALCHEMY_DATABASE_URL = "postgresql+pg8000://"
 
+    engine = create_engine(SQLALCHEMY_DATABASE_URL, creator=getconn)
+    return engine
 
-SQLALCHEMY_DATABASE_URL = "postgresql+pg8000://"
+# initialize Python Connector and connection pool engine
+connector = Connector()
+engine = init_connection_engine(connector)
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL, creator=getconn)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/tabs-vs-spaces/app/database.py
+++ b/tabs-vs-spaces/app/database.py
@@ -18,7 +18,8 @@ def init_connection_engine(connector: Connector) -> Engine:
         (os.getenv("DB_IAM_USER"), True)
         if os.getenv("DB_IAM_USER")
         else (os.getenv("DB_USER"), False)
-    ) 
+    )
+
     # Cloud SQL Python Connector creator function
     def getconn():
         conn = connector.connect(
@@ -31,11 +32,12 @@ def init_connection_engine(connector: Connector) -> Engine:
             enable_iam_auth=enable_iam_auth,
         )
         return conn
-    
+
     SQLALCHEMY_DATABASE_URL = "postgresql+pg8000://"
 
     engine = create_engine(SQLALCHEMY_DATABASE_URL, creator=getconn)
     return engine
+
 
 # initialize Python Connector and connection pool engine
 connector = Connector()

--- a/tabs-vs-spaces/app/database.py
+++ b/tabs-vs-spaces/app/database.py
@@ -1,6 +1,7 @@
 import os
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from google.cloud.sql.connector import Connector, IPTypes
@@ -9,8 +10,7 @@ from google.cloud.sql.connector import Connector, IPTypes
 load_dotenv()
 
 
-# Cloud SQL Python Connector creator function
-def getconn():
+def init_connection_engine(connector: Connector) -> Engine:
     # if env var PRIVATE_IP is set to True, use private IP Cloud SQL connections
     ip_type = IPTypes.PRIVATE if os.getenv("PRIVATE_IP") is True else IPTypes.PUBLIC
     # if env var DB_IAM_USER is set, use IAM database authentication
@@ -18,22 +18,29 @@ def getconn():
         (os.getenv("DB_IAM_USER"), True)
         if os.getenv("DB_IAM_USER")
         else (os.getenv("DB_USER"), False)
-    )
-    # initialize Cloud SQL Python connector object
-    with Connector(ip_type=ip_type, enable_iam_auth=enable_iam_auth) as connector:
+    ) 
+    # Cloud SQL Python Connector creator function
+    def getconn():
         conn = connector.connect(
             os.getenv("INSTANCE_CONNECTION_NAME"),
             "pg8000",
             user=user,
             password=os.getenv("DB_PASS", ""),
             db=os.getenv("DB_NAME"),
+            ip_type=ip_type,
+            enable_iam_auth=enable_iam_auth,
         )
         return conn
+    
+    SQLALCHEMY_DATABASE_URL = "postgresql+pg8000://"
 
+    engine = create_engine(SQLALCHEMY_DATABASE_URL, creator=getconn)
+    return engine
 
-SQLALCHEMY_DATABASE_URL = "postgresql+pg8000://"
+# initialize Python Connector and connection pool engine
+connector = Connector()
+engine = init_connection_engine(connector)
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL, creator=getconn)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()


### PR DESCRIPTION
Moving `Connector` initialization out of `getconn` as getconn is called for each new database connection, where as the `Connector` should be re-used for all connections.